### PR TITLE
hashmap: compare length

### DIFF
--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -144,8 +144,13 @@ int hashmap_get(hashmap *map, const char *key, void **value) {
  * @arg should_cmp Should keys be compared to existing ones.
  * @return 1 if the key is new, 0 if updated.
  */
-static int hashmap_insert_table(hashmap_entry *table, int table_size, char *key, int key_len,
-                                void *value, void *metadata, int should_cmp) {
+static int hashmap_insert_table(hashmap_entry *table,
+        int table_size,
+        const char *key,
+        int key_len,
+        void *value,
+        void *metadata,
+        int should_cmp) {
     // Compute the hash value of the key
     uint32_t out = murmur3_32(key, key_len, 0);
 
@@ -172,7 +177,7 @@ static int hashmap_insert_table(hashmap_entry *table, int table_size, char *key,
     // If last entry is NULL, we can just insert directly into the
     // table slot since it is empty
     if (entry && last_entry == NULL) {
-        entry->key = (key);
+        entry->key = strdup(key);
         entry->value = value;
         entry->metadata = metadata;
         entry->next = NULL;
@@ -180,7 +185,7 @@ static int hashmap_insert_table(hashmap_entry *table, int table_size, char *key,
         // value.
     } else if (last_entry) {
         entry = calloc(1, sizeof(hashmap_entry));
-        entry->key = (key);
+        entry->key = strdup(key);
         entry->value = value;
         entry->metadata = metadata;
         last_entry->next = entry;
@@ -254,16 +259,12 @@ int hashmap_put(hashmap *map, const char *key, void *value, void *metadata) {
         return hashmap_put(map, key, value, metadata);
     }
 
-    char* insert_key = strdup(key);
-
     // Insert into the map, comparing keys and duplicating keys
-    int new = hashmap_insert_table(map->table, map->table_size, insert_key, strlen(key), value, metadata, 1);
+    int new = hashmap_insert_table(map->table, map->table_size, key,
+                                   strlen(key), value, metadata, 1);
     if (new > 0) {
         map->count += 1;
-    } else {
-        free(insert_key);
     }
-
     return new;
 }
 

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -110,8 +110,8 @@ int hashmap_size(hashmap *map) {
 /**
  * Returns the hash entry for key.
  */
-static hashmap_entry *hashmap_lookup(hashmap_entry *table, int table_size,
-                                     const char *key, size_t key_len) {
+static hashmap_entry *hashmap_index(hashmap_entry *table, int table_size,
+                                    const char *key, size_t key_len) {
     // Mod the lower 64bits of the hash function with the table
     // size to get the index
     return table + (uint32_t)(murmur3_32(key, key_len, 0) % table_size);
@@ -135,7 +135,7 @@ static inline int hashmap_keys_equal(const hashmap_entry *entry, const char *key
 int hashmap_get(hashmap *map, const char *key, void **value) {
     // Compute the hash value of the key
     const size_t key_len = strlen(key);
-    hashmap_entry *entry = hashmap_lookup(map->table, map->table_size, key, key_len);
+    hashmap_entry *entry = hashmap_index(map->table, map->table_size, key, key_len);
 
     // Scan the keys
     while (entry && entry->key) {
@@ -172,7 +172,7 @@ static int hashmap_insert_table(hashmap_entry *table,
         void *metadata,
         int should_cmp) {
     // Look for an entry
-    hashmap_entry *entry = hashmap_lookup(table, table_size, key, key_len);
+    hashmap_entry *entry = hashmap_index(table, table_size, key, key_len);
     // last_entry governs if we saw any nodes with keys
     hashmap_entry *last_entry = NULL;
 
@@ -308,7 +308,7 @@ int hashmap_put(hashmap *map, const char *key, void *value, void *metadata) {
 int hashmap_delete(hashmap *map, const char *key) {
     // Compute the hash value of the key
     const size_t key_len = strlen(key);
-    hashmap_entry *entry = hashmap_lookup(map->table, map->table_size, key, key_len);
+    hashmap_entry *entry = hashmap_index(map->table, map->table_size, key, key_len);
     hashmap_entry *last_entry = NULL;
 
     // Scan the keys

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -102,11 +102,6 @@ int hashmap_size(hashmap *map) {
     return map->count;
 }
 
-// TODO (CEV):
-//  1. Make sure there are no type conversion issues (int vs. uint)
-//  2. Make sure this is inlined
-//  3. Consider using a macro
-//  4. Rename
 /**
  * Returns the hash entry for key.
  */
@@ -196,7 +191,7 @@ static int hashmap_insert_table(hashmap_entry *table,
     // We already know the key length - no point using strdup
     char *insert_key = malloc(key_len + 1);
     if (insert_key == NULL) {
-        return -1; // WARN (CEV): handle OOM
+        return -1;
     }
     memcpy(insert_key, key, key_len + 1);
 
@@ -215,7 +210,7 @@ static int hashmap_insert_table(hashmap_entry *table,
         entry = calloc(1, sizeof(hashmap_entry));
         if (entry == NULL) {
             free(insert_key);
-            return -1; // WARN (CEV): handle OOM
+            return -1;
         }
         entry->key_len = key_len;
         entry->key = insert_key;


### PR DESCRIPTION
**Note:** This builds on https://github.com/lyft/statsrelay/pull/33 - I didn't want to deal with a merge conflict on master, but happy to rebase the PR.

Adding the key length to the hashmap entry should improve performance by allowing us to replace `strcmp()` with a length check + `memcmp()`.

Additionally, this PR cleans up and consolidates the hashmap logic.