### PR TITLE
log: convert log functions to macros

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -26,7 +26,11 @@ void stats_set_log_level(enum statsrelay_log_level level) {
     g_level = level;
 }
 
-void stats_vlog(const char *prefix,
+enum statsrelay_log_level stats_get_log_level() {
+    return g_level;
+}
+
+static void stats_vlog(const char *prefix,
         const char *format,
         va_list ap) {
     int fmt_len;
@@ -109,7 +113,7 @@ alloc_failure:
     return;
 }
 
-void stats_debug_log(const char *format, ...) {
+void noinline stats_debug_log_impl(const char *format, ...) {
     if (g_level <= STATSRELAY_LOG_DEBUG) {
         va_list args;
         va_start(args, format);
@@ -118,7 +122,7 @@ void stats_debug_log(const char *format, ...) {
     }
 }
 
-void stats_log(const char *format, ...) {
+void stats_log_impl(const char *format, ...) {
     if (g_level <= STATSRELAY_LOG_INFO) {
         va_list args;
         va_start(args, format);
@@ -127,7 +131,7 @@ void stats_log(const char *format, ...) {
     }
 }
 
-void stats_error_log(const char *format, ...) {
+void stats_error_log_impl(const char *format, ...) {
     if (g_level <= STATSRELAY_LOG_ERROR) {
         bool orig_verbose = g_verbose;
         g_verbose = true;

--- a/src/log.h
+++ b/src/log.h
@@ -4,12 +4,18 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
+#define noinline __attribute__((__noinline__))
+#define stats_printf __attribute__((__format__(__printf__, 1, 2)))
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
 enum statsrelay_log_level {
     STATSRELAY_LOG_DEBUG   = 10,
     STATSRELAY_LOG_INFO    = 20,
     STATSRELAY_LOG_WARN    = 30,
     STATSRELAY_LOG_ERROR   = 40
 };
+
+// TODO (CEV): most of these should be marked 'noinline'
 
 // set verbose logging, i.e. send logs to stderr
 void stats_log_verbose(bool verbose);
@@ -19,20 +25,31 @@ void stats_log_syslog(bool syslog);
 
 void stats_set_log_level(enum statsrelay_log_level level);
 
-// variadic log function
-void stats_vlog(const char *prefix, const char *format, va_list ap);
+enum statsrelay_log_level stats_get_log_level() __attribute__((pure));
 
 // log a message
-void stats_log(const char *format, ...);
+void noinline stats_log_impl(const char *format, ...) stats_printf;
 
 // log a debug message
-void stats_debug_log(const char *format, ...);
+void noinline stats_debug_log_impl(const char *format, ...) stats_printf;
 
 // log an error message
-void stats_error_log(const char *format, ...);
+void noinline stats_error_log_impl(const char *format, ...) stats_printf;
 
 // finish logging; this ensures that the internally allocated buffer is freed;
 // it can safely be called multiple times
 void stats_log_end(void);
+
+#define stats_log(format, ...) \
+	if (unlikely(stats_get_log_level() <= STATSRELAY_LOG_INFO)) \
+		stats_log_impl(format, ##__VA_ARGS__);
+
+#define stats_error_log(format, ...) \
+	if (unlikely(stats_get_log_level() <= STATSRELAY_LOG_ERROR)) \
+		stats_error_log_impl(format, ##__VA_ARGS__);
+
+#define stats_debug_log(format, ...) \
+	if (unlikely(stats_get_log_level() <= STATSRELAY_LOG_DEBUG)) \
+		stats_debug_log_impl(format, ##__VA_ARGS__);
 
 #endif

--- a/src/log.h
+++ b/src/log.h
@@ -15,8 +15,6 @@ enum statsrelay_log_level {
     STATSRELAY_LOG_ERROR   = 40
 };
 
-// TODO (CEV): most of these should be marked 'noinline'
-
 // set verbose logging, i.e. send logs to stderr
 void stats_log_verbose(bool verbose);
 


### PR DESCRIPTION
This will improve performance and is pretty standard, but the use of variadic macros (a GNU extension supported by Clang) is a little controversial.  In particular, things like `stats_debug_log` kill performance as: A) you never want them to be inlined B) va_args C) you gotta deal with all this before you even know if you should log or return as a NOP.

#### Changes:
* Always assume the log function should not be called this improves production performance at the cost of debug performance.  In production we only log WARN/ERROR so performance doesn't matter when we have to log since the caller is already in a bad state.

* Mark all log functions as "never inline"

* Add the format attribute to log functions to improve compiler warnings.

NOTE: This takes advantage of the GCC variadic macro extension, but works with Clang (though a warning is emitted).