### PR TITLE
Init last_gc, log elide hashmap size after GC

### DIFF
--- a/src/elide.c
+++ b/src/elide.c
@@ -80,6 +80,7 @@ int elide_gc(elide_t* e, struct timeval cutoff) {
         };
         int pre_count = hashmap_size(e->elide_map);
         hashmap_filter(e->elide_map, elide_gc_cb, (void *) &cb);
+        stats_log("elide hashmap tablesize=%d size=%d", hashmap_tablesize(e->elide_map), hashmap_size(e->elide_map));
 
         struct timeval now;
         gettimeofday(&now, NULL);

--- a/src/elide.c
+++ b/src/elide.c
@@ -74,13 +74,16 @@ int elide_gc(elide_t* e, struct timeval cutoff) {
     }
 
     // compare seconds only
+    stats_log("elide_gc last_gc=%u cutoff=%u", e->last_gc.tv_sec, cutoff.tv_sec);
     if (e->last_gc.tv_sec < cutoff.tv_sec) {
+        stats_log("elide_gc performing gc");
         struct cb_info cb = {
                 .cutoff = cutoff
         };
         int pre_count = hashmap_size(e->elide_map);
+        stats_log("elide hashmap before tablesize=%d size=%d", hashmap_tablesize(e->elide_map), hashmap_size(e->elide_map));
         hashmap_filter(e->elide_map, elide_gc_cb, (void *) &cb);
-        stats_log("elide hashmap tablesize=%d size=%d", hashmap_tablesize(e->elide_map), hashmap_size(e->elide_map));
+        stats_log("elide hashmap after tablesize=%d size=%d", hashmap_tablesize(e->elide_map), hashmap_size(e->elide_map));
 
         struct timeval now;
         gettimeofday(&now, NULL);

--- a/src/elide.c
+++ b/src/elide.c
@@ -9,6 +9,9 @@ int elide_init(elide_t** e, int skip) {
     elide_t* el = malloc(sizeof(elide_t));
     int res = hashmap_init(0, &el->elide_map);
     el->skip = skip;
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    el->last_gc = now;
     *e = el;
     return res;
 }
@@ -65,25 +68,14 @@ static int elide_gc_cb(void* data, const char *key, void* value, void *metadata)
 }
 
 int elide_gc(elide_t* e, struct timeval cutoff) {
-    // initialize last_gc with now, if never called
-    if (e->last_gc.tv_sec == 0) {
-        struct timeval now;
-        gettimeofday(&now, NULL);
-        e->last_gc = now;
-        return 0;
-    }
-
     // compare seconds only
-    stats_log("elide_gc last_gc=%u cutoff=%u", e->last_gc.tv_sec, cutoff.tv_sec);
     if (e->last_gc.tv_sec < cutoff.tv_sec) {
-        stats_log("elide_gc performing gc");
         struct cb_info cb = {
                 .cutoff = cutoff
         };
         int pre_count = hashmap_size(e->elide_map);
-        stats_log("elide hashmap before tablesize=%d size=%d", hashmap_tablesize(e->elide_map), hashmap_size(e->elide_map));
         hashmap_filter(e->elide_map, elide_gc_cb, (void *) &cb);
-        stats_log("elide hashmap after tablesize=%d size=%d", hashmap_tablesize(e->elide_map), hashmap_size(e->elide_map));
+        stats_log("gc complete, hashmap tablesize=%d size=%d", hashmap_tablesize(e->elide_map), hashmap_size(e->elide_map));
 
         struct timeval now;
         gettimeofday(&now, NULL);

--- a/src/elide.h
+++ b/src/elide.h
@@ -2,6 +2,7 @@
 #define STATSRELAY_ELIDE_H
 
 #include "hashmap.h"
+#include "log.h"
 
 typedef struct {
     /* Generations is the number of squential 0 values */

--- a/src/stats.c
+++ b/src/stats.c
@@ -20,7 +20,7 @@
 const int ELIDE_PERIOD = 10;
 
 // entries older than this in seconds will be removed from the elision hashmap
-const int ELIDE_GC_PERIOD = 60*15;
+const int ELIDE_GC_PERIOD = 60*1;
 
 // Forward declare
 static void stats_write_to_backend(const char *line,

--- a/src/stats.c
+++ b/src/stats.c
@@ -20,7 +20,7 @@
 const int ELIDE_PERIOD = 10;
 
 // entries older than this in seconds will be removed from the elision hashmap
-const int ELIDE_GC_PERIOD = 60*1;
+const int ELIDE_GC_PERIOD = 60*15;
 
 // Forward declare
 static void stats_write_to_backend(const char *line,
@@ -816,7 +816,6 @@ static int gc_elide(elide_t* elide) {
     struct timeval cutoff;
     gettimeofday(&cutoff, NULL);
     cutoff.tv_sec -= ELIDE_GC_PERIOD;
-    stats_log("gc_elide cutoff=%u", cutoff.tv_sec);
 
     return elide_gc(elide, cutoff);
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -816,6 +816,7 @@ static int gc_elide(elide_t* elide) {
     struct timeval cutoff;
     gettimeofday(&cutoff, NULL);
     cutoff.tv_sec -= ELIDE_GC_PERIOD;
+    stats_log("gc_elide cutoff=%u", cutoff.tv_sec);
 
     return elide_gc(elide, cutoff);
 }


### PR DESCRIPTION
Initializes `last_gc` when `elide_init` is called.

Debug logging added in the intermediate commit showed an initial value of 1676033424 for `tv_sec`, not the 0 the code was expecting, preventing GC from running:

```
main(5062): Starting event loop.
tcpclient[127.0.0.1/9999/tcp]: State transition CONNECTING -> CONNECTED
DEBUG: tcplistener_accept_callback pid:5062, parentpid:1
DEBUG: stats: accepted client connection on fd 8
DEBUG: stats: received 16 bytes from tcp client fd 8
gc_elide cutoff=1594941325
elide_gc last_gc=1676033424 cutoff=1594941325
```

Also logs the elide hashmap size after GC.

JIRA: [METRICS-708](https://jira.lyft.net/browse/METRICS-708)