### PR TITLE
Revert hashmap_iter

### DIFF
--- a/src/elide.c
+++ b/src/elide.c
@@ -41,8 +41,7 @@ int elide_unmark(elide_t* e, char *key, struct timeval now) {
 }
 
 static int elide_delete_cb(void* data, const char *key, void* value, void *metadata) {
-    free(value);
-    return 0;
+    return HASHMAP_ITER_DELETE;
 }
 
 int elide_destroy(elide_t* e) {


### PR DESCRIPTION
Valgrind [implicated](https://github.lyft.net/gist/mgoldsby/6f9e06b5d446efbcc3cff44281364985) `expiry_callback` called from `hashmap_iter`, which was changed such that it was no longer properly cleaning up after deleted entries. This restores the original behavior, which should no longer try to free the same entry twice.