### PR TITLE
Handle inner mutability of StatsdBackend shard mapping

### DIFF
--- a/src/shard.rs
+++ b/src/shard.rs
@@ -42,6 +42,10 @@ impl<C: Send + Sync + 'static> Ring<C> {
         let c = &mut self.members[code as usize % len];
         f(c);
     }
+
+    pub fn swap(&mut self, other: Ring<C>) {
+        self.members = other.members;
+    }
 }
 
 #[cfg(test)]
@@ -49,6 +53,21 @@ pub mod test {
     use super::*;
     use bytes::Bytes;
 
+    #[test]
+    fn test_swap() {
+        let mut ring = Ring::new();
+        ring.push(0);
+        ring.push(1);
+        assert_eq!(ring.len(), 2);
+        let mut ring2 = Ring::new();
+        ring2.push(2);
+        ring2.push(3);
+        ring2.push(4);
+        assert_eq!(ring2.len(), 3);
+        ring.swap(ring2);
+        assert_eq!(ring.len(), 3);
+
+    }
     #[test]
     fn test_hash() {
         let mut ring = Ring::new();


### PR DESCRIPTION
This is one method of re-using the internals of a shard map and
allowing an inner mutability step. Nothing actually mutates it yet,
since I'm going to feedback here.

Upsides: loose coupling between shard updates and backend updates

Downsides: Yet another RwLock in a hot path for allowing safe swapping
of the mapping. There are other techniques we could do here like
lazy-load from another structure or an atomic load of the map, but its
somewhat harder to reason about.

Alternative: We never mutate the internals of a StatsdBackend and
instead use the outer mutability we alreday have in the `Backends`
struct to simply replace the whole thing in one shot. There is already
a RwLock here and we can still do some games with reusing the existing
clients amongst backends.