### PR TITLE
Allow re-loading config to re-build backends

### DIFF
--- a/src/backends.rs
+++ b/src/backends.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
@@ -19,7 +20,7 @@ struct StatsdBackend {
 }
 
 impl StatsdBackend {
-    fn new(conf: &StatsdDuplicateTo) -> anyhow::Result<Self> {
+    fn new(conf: &StatsdDuplicateTo, client_ref: Option<&StatsdBackend>) -> anyhow::Result<Self> {
         let mut filters: Vec<String> = Vec::new();
 
         // This is ugly, sorry
@@ -35,20 +36,42 @@ impl StatsdBackend {
             None
         };
 
-        let mut backend = StatsdBackend {
+        let mut ring: Ring<StatsdClient> = Ring::new();
+
+        // Use the same backend for the same endpoint address, caching the lookup locally
+        let mut memoize: HashMap<String, StatsdClient> =
+            client_ref.map_or_else(|| HashMap::new(), |b| b.clients());
+        for endpoint in &conf.shard_map {
+            if let Some(client) = memoize.get(endpoint) {
+                ring.push(client.clone())
+            } else {
+                let client = StatsdClient::new(endpoint.as_str(), 100000);
+                memoize.insert(endpoint.clone(), client.clone());
+                ring.push(client);
+            }
+        }
+
+        let backend = StatsdBackend {
             conf: conf.clone(),
-            ring: Ring::new(),
+            ring: ring,
             input_filter: input_filter,
             warning_log: AtomicU64::new(0),
         };
 
-        for endpoint in &conf.shard_map {
-            backend
-                .ring
-                .push(StatsdClient::new(endpoint.as_str(), 100000));
-        }
-
         Ok(backend)
+    }
+
+    // Capture the old ring contents into a memoization map by endpoint,
+    // letting us re-use any old client connections and buffers. Note we
+    // won't start tearing down connections until the memoization buffer and
+    // old ring are both dropped.
+    fn clients(&self) -> HashMap<String, StatsdClient> {
+        let mut memoize: HashMap<String, StatsdClient> = HashMap::new();
+        for i in 0..self.ring.len() {
+            let client = self.ring.pick_from(i as u32);
+            memoize.insert(String::from(client.endpoint()), client.clone());
+        }
+        memoize
     }
 
     fn provide_statsd_pdu(&self, pdu: &StatsdPDU) {
@@ -59,13 +82,14 @@ impl StatsdBackend {
         {
             return;
         }
-        // All the other logic
 
-        let code = match self.ring.len() {
+        let ring_read = &self.ring;
+        let code = match ring_read.len() {
+            0 => return, // In case of nothing to send, do nothing
             1 => 1 as u32,
             _ => statsrelay_compat_hash(pdu),
         };
-        let client = self.ring.pick_from(code);
+        let client = ring_read.pick_from(code);
         let mut sender = client.sender();
 
         // Assign prefix and/or suffix
@@ -113,8 +137,18 @@ impl BackendsInner {
         BackendsInner { statsd: vec![] }
     }
 
-    fn add_statsd_backend(&mut self, c: &StatsdDuplicateTo) {
-        self.statsd.push(StatsdBackend::new(c).unwrap());
+    fn add_statsd_backend(&mut self, c: &StatsdDuplicateTo) -> anyhow::Result<()> {
+        self.statsd.push(StatsdBackend::new(c, None)?);
+        Ok(())
+    }
+
+    fn replace_statsd_backend(&mut self, idx: usize, c: &StatsdDuplicateTo) -> anyhow::Result<()> {
+        let backend = match self.statsd.get(idx) {
+            None => return self.add_statsd_backend(c),
+            Some(backend) => backend,
+        };
+        self.statsd[idx] = StatsdBackend::new(c, Some(backend))?;
+        Ok(())
     }
 
     fn provide_statsd_pdu(&self, pdu: StatsdPDU) {
@@ -142,8 +176,12 @@ impl Backends {
         }
     }
 
-    pub fn add_statsd_backend(&self, c: &StatsdDuplicateTo) {
-        self.inner.write().add_statsd_backend(c);
+    pub fn add_statsd_backend(&self, c: &StatsdDuplicateTo) -> anyhow::Result<()> {
+        self.inner.write().add_statsd_backend(c)
+    }
+
+    pub fn replace_statsd_backend(&self, idx: usize, c: &StatsdDuplicateTo) -> anyhow::Result<()> {
+        self.inner.write().replace_statsd_backend(idx, c)
     }
 
     pub fn provide_statsd_pdu(&self, pdu: StatsdPDU) {

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -122,5 +122,12 @@ async fn reload_config_from_file(backends: &backends::Backends, path: &str) {
                 continue;
             }
         }
+        if backends.len() > duplicate.len() {
+            for idx in duplicate.len()+1..backends.len() {
+                if let Err(e) = backends.remove_statsd_backend(idx) {
+                    error!("failed to remove backend block {} with error {}", idx, e);
+                }
+            }
+        }
     }
 }

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -48,7 +48,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let mut runtime = builder.enable_all().build().unwrap();
-    debug!("built tokio runtime");
+    info!("tokio runtime built, threaded: {}", opts.threaded);
 
     runtime.block_on(async move {
         let backends = backends::Backends::new();

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -6,7 +6,7 @@ use tokio::select;
 use tokio::signal::unix::{signal, SignalKind};
 
 use env_logger::Env;
-use log::{debug, info};
+use log::{debug, error, info};
 use metrics_runtime::Receiver;
 
 use statsrelay::backends;
@@ -16,6 +16,9 @@ use statsrelay::statsd_server;
 struct Options {
     #[structopt(short = "c", long = "--config", default_value = "/etc/statsrelay.json")]
     pub config: String,
+
+    #[structopt(short = "t", long = "--threaded")]
+    pub threaded: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -38,23 +41,33 @@ fn main() -> anyhow::Result<()> {
 
     debug!("installed metrics receiver");
 
-    let mut threaded_rt = runtime::Builder::new()
-        .enable_all()
-        .threaded_scheduler()
-        .build()
-        .unwrap();
+    let mut builder = &mut runtime::Builder::new();
+    builder = match opts.threaded {
+        true => builder.threaded_scheduler(),
+        false => builder.basic_scheduler(),
+    };
 
+    let mut runtime = builder.enable_all().build().unwrap();
     debug!("built tokio runtime");
 
-    threaded_rt.block_on(async move {
+    runtime.block_on(async move {
         let backends = backends::Backends::new();
-        if config.statsd.shard_map.len() > 0 {
-            backends.add_statsd_backend(&statsrelay::config::StatsdDuplicateTo::from_shards(
-                config.statsd.shard_map.clone(),
-            ));
+        // Load the default backend set, even if its zero sized, to avoid index
+        // errors later
+        if let Err(e) = backends.add_statsd_backend(
+            &statsrelay::config::StatsdDuplicateTo::from_shards(config.statsd.shard_map.clone()),
+        ) {
+            error!("invalid backend created {}", e);
+            return;
+        }
+        for duplicate_to_block in config.statsd.duplicate_to.map_or(vec![], |f| f) {
+            if let Err(e) = backends.add_statsd_backend(&duplicate_to_block) {
+                error!("invalid backend created {}", e);
+                return;
+            }
         }
         let (sender, tripwire) = Tripwire::new();
-        let run = statsd_server::run(tripwire, config.statsd.bind.clone(), backends);
+        let run = statsd_server::run(tripwire, config.statsd.bind.clone(), backends.clone());
 
         // Trap ctrl+c and sigterm messages and perform a clean shutdown
         let mut sigint = signal(SignalKind::interrupt()).unwrap();
@@ -67,10 +80,47 @@ fn main() -> anyhow::Result<()> {
             sender.cancel();
         });
 
+        // Trap sighup to support manual file reloading
+        let mut sighup = signal(SignalKind::hangup()).unwrap();
+        tokio::spawn(async move {
+            loop {
+                sighup.recv().await;
+                info!("reloading configuration and replacing backends");
+                reload_config_from_file(&backends, opts.config.as_ref()).await;
+            }
+        });
+
         run.await;
     });
 
-    drop(threaded_rt);
+    drop(runtime);
     info!("runtime terminated");
     Ok(())
+}
+
+async fn reload_config_from_file(backends: &backends::Backends, path: &str) {
+    let config = match statsrelay::config::load_legacy_config(path)
+        .with_context(|| format!("can't load config file from {}", path))
+    {
+        Err(e) => {
+            error!("failed to reload configuration: {}", e);
+            return;
+        }
+        Ok(ok) => ok,
+    };
+
+    if let Err(e) = backends.replace_statsd_backend(
+        0,
+        &statsrelay::config::StatsdDuplicateTo::from_shards(config.statsd.shard_map.clone()),
+    ) {
+        error!("invalid backend created {}", e);
+    }
+    if let Some(duplicate) = config.statsd.duplicate_to {
+        for (idx, dp) in duplicate.iter().enumerate() {
+            if let Err(e) = backends.replace_statsd_backend(idx, dp) {
+                error!("failed to replace backend index {} error {}", idx, e);
+                continue;
+            }
+        }
+    }
 }

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -130,4 +130,5 @@ async fn reload_config_from_file(backends: &backends::Backends, path: &str) {
             }
         }
     }
+    info!("backends reloaded");
 }

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -42,6 +42,10 @@ impl<C: Send + Sync + 'static> Ring<C> {
         let c = &mut self.members[code as usize % len];
         f(c);
     }
+
+    pub fn swap(&mut self, other: Ring<C>) {
+        self.members = other.members;
+    }
 }
 
 #[cfg(test)]
@@ -49,6 +53,21 @@ pub mod test {
     use super::*;
     use bytes::Bytes;
 
+    #[test]
+    fn test_swap() {
+        let mut ring = Ring::new();
+        ring.push(0);
+        ring.push(1);
+        assert_eq!(ring.len(), 2);
+        let mut ring2 = Ring::new();
+        ring2.push(2);
+        ring2.push(3);
+        ring2.push(4);
+        assert_eq!(ring2.len(), 3);
+        ring.swap(ring2);
+        assert_eq!(ring.len(), 3);
+
+    }
     #[test]
     fn test_hash() {
         let mut ring = Ring::new();


### PR DESCRIPTION
This is the other method to do reloading of backend shards, by just
replacing the entire backend but transferring any existing clients
over. Old unused clients will simply be dropped and then shut down (as
we would drop the tripwire trigger).

This has more advantages than the last PR, as it allows us to update a
lot more internal state, but fixes issues with re-using clients.