### PR TITLE
Swap allocator to jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "futures"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +691,27 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -1451,6 +1478,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hyper",
+ "jemallocator",
  "log",
  "memchr",
  "murmur3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ env_logger = "0.8"
 # Internal stats
 prometheus = "0.11"
 
+# malloc
+jemallocator = "0.3.0"
+
 [dev-dependencies]
 tempfile = "3.1"
 

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -1,3 +1,8 @@
+extern crate jemallocator;
+
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use anyhow::Context;
 use futures::StreamExt;
 use stream_cancel::Tripwire;


### PR DESCRIPTION
In cases of high allocation and then queue draining, the high water mark with glibc malloc was terrible. jemalloc appears to handle freeing pages back to the OS much better.

Specifically, Glibc malloc arena behavior would spawn up to 64MB*8*core (so, 64 core) per process, even if we are using the single threaded executor as we had more than one thread running (main + admin + blocking thread + UDP). We could get to a 1G RSS pretty easily, even though our retention was much much smaller than that.