### PR TITLE
Support unix sockets for the statsd server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "async-stream"
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "bytes"
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 dependencies = [
  "jobserver",
 ]
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+checksum = "076a6803b0dacd6a88cfe64deba628b01533ff5ef265687e6938280c1afd0a28"
 
 [[package]]
 name = "core-foundation"
@@ -252,12 +252,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if",
- "const_fn",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -276,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -377,9 +376,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -393,9 +392,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -408,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -418,15 +417,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -435,15 +434,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -453,24 +452,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -522,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
 dependencies = [
  "bytes",
  "fnv",
@@ -537,7 +533,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -566,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -593,12 +588,13 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
  "bytes",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -621,9 +617,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -635,7 +631,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project",
  "socket2",
  "tokio",
  "tower-service",
@@ -658,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -669,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -730,9 +726,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libgit2-sys"
@@ -760,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
 dependencies = [
  "scopeguard",
 ]
@@ -796,18 +792,18 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -818,11 +814,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
@@ -896,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -908,15 +903,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -928,9 +923,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
  "autocfg",
  "cc",
@@ -972,38 +967,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
 dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
-dependencies = [
- "pin-project-internal 1.0.5",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1012,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1072,9 +1047,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -1096,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.22.0"
+version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f72884896d22e0da0e5b266cb9a780b791f6c3b2f5beab6368d6cd4f0dbb86"
+checksum = "1b7f4a129bb3754c25a4e04032a90173c68f85168f77118ac4cb4936e7f06f92"
 
 [[package]]
 name = "qp-trie"
@@ -1143,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
@@ -1161,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1180,21 +1155,20 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -1282,7 +1256,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "sha2",
- "time 0.2.25",
+ "time 0.2.26",
  "tokio",
 ]
 
@@ -1319,9 +1293,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1332,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1358,18 +1332,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1378,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1435,20 +1409,19 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if",
  "libc",
  "winapi",
 ]
 
 [[package]]
 name = "standback"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2beb4d1860a61f571530b3f855a1b538d0200f7871c63331ecd6f17b1f014f8"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
@@ -1555,7 +1528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36848ff9e3e8af125e00ab244aca7af0a8b270d4c6afcc9ccb4e523f7972c4c"
 dependencies = [
  "futures-core",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
 ]
 
@@ -1597,9 +1570,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,31 +1613,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -1679,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
+checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
 dependencies = [
  "const_fn",
  "libc",
@@ -1717,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1732,9 +1696,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1773,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1784,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1813,9 +1777,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1832,16 +1796,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
-dependencies = [
- "pin-project 0.4.27",
- "tracing",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,15 +1803,15 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -1900,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1924,9 +1878,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"
@@ -1952,9 +1906,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1962,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1977,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1987,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2000,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "winapi"

--- a/examples/tugboat-discovery.json
+++ b/examples/tugboat-discovery.json
@@ -1,9 +1,11 @@
 {
     "statsd": {
-        "bind": "127.0.0.1:8129",
-        "point_tag_regex": "\\.__([a-zA-Z][a-zA-Z0-9_]+)=[a-zA-Z0-9_/-]+",
-        "tcp_cork": true,
-        "validate": true,
+        "servers": {
+            "default": {
+                "bind": "127.0.0.1:8129",
+                "socket": "/tmp/statsrelay"
+            }
+        },
         "backends": {
             "simple": {
                 "shard_map": [

--- a/examples/tugboat-legacy-basic.json
+++ b/examples/tugboat-legacy-basic.json
@@ -3,10 +3,11 @@
         "port": 9001
     },
     "statsd": {
-        "bind": "127.0.0.1:8129",
-        "point_tag_regex": "\\.__([a-zA-Z][a-zA-Z0-9_]+)=[a-zA-Z0-9_/-]+",
-        "tcp_cork": true,
-        "validate": true,
+        "servers": {
+            "default": {
+                "bind": "127.0.0.1:8129"
+            }
+        },
         "backends": {
             "simple": {
                 "shard_map": [

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -7,7 +7,7 @@ use regex::bytes::RegexSet;
 use statsdproto::statsd::StatsdPDU;
 use thiserror::Error;
 
-use crate::config::StatsdDuplicateTo;
+use crate::config;
 use crate::discovery;
 use crate::shard::{statsrelay_compat_hash, Ring};
 use crate::stats;
@@ -16,7 +16,7 @@ use crate::statsd_client::StatsdClient;
 use log::warn;
 
 struct StatsdBackend {
-    conf: StatsdDuplicateTo,
+    conf: config::StatsdBackendConfig,
     ring: Ring<StatsdClient>,
     input_filter: Option<RegexSet>,
     warning_log: AtomicU64,
@@ -27,7 +27,7 @@ struct StatsdBackend {
 impl StatsdBackend {
     fn new(
         stats: stats::Scope,
-        conf: &StatsdDuplicateTo,
+        conf: &config::StatsdBackendConfig,
         client_ref: Option<&StatsdBackend>,
         discovery_update: Option<&discovery::Update>,
     ) -> anyhow::Result<Self> {
@@ -173,7 +173,7 @@ impl BackendsInner {
     fn replace_statsd_backend(
         &mut self,
         name: &String,
-        c: &StatsdDuplicateTo,
+        c: &config::StatsdBackendConfig,
         discovery_update: Option<&discovery::Update>,
     ) -> anyhow::Result<()> {
         let previous = self.statsd.get(name);
@@ -228,7 +228,7 @@ impl Backends {
     pub fn replace_statsd_backend(
         &self,
         name: &String,
-        c: &StatsdDuplicateTo,
+        c: &config::StatsdBackendConfig,
         discovery_update: Option<&discovery::Update>,
     ) -> anyhow::Result<()> {
         self.inner

--- a/src/cmd/loadgen.rs
+++ b/src/cmd/loadgen.rs
@@ -1,9 +1,9 @@
 use bytes::{BufMut, BytesMut};
 use chrono::prelude::*;
+use std::time::Duration;
 use structopt::StructOpt;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use std::time::Duration;
 
 const PRINT_INTERVAL: u64 = 100000;
 

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -5,6 +5,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use anyhow::Context;
 use futures::StreamExt;
+use futures::{stream::FuturesUnordered, FutureExt};
 use stream_cancel::Tripwire;
 use structopt::StructOpt;
 
@@ -17,12 +18,12 @@ use tokio::signal::unix::{signal, SignalKind};
 use env_logger::Env;
 use log::{debug, error, info};
 
-use statsrelay::admin;
 use statsrelay::backends;
 use statsrelay::config;
 use statsrelay::discovery;
 use statsrelay::stats;
 use statsrelay::statsd_server;
+use statsrelay::{admin, config::Config};
 
 #[derive(StructOpt, Debug)]
 struct Options {
@@ -31,6 +32,86 @@ struct Options {
 
     #[structopt(short = "t", long = "--threaded")]
     pub threaded: bool,
+}
+
+/// The main server invocation, for a given configuration, options and stats
+/// scope. The server will spawn any listeners, initialize a backend
+/// configuration update loop, as well as register signal handlers.
+async fn server(scope: stats::Scope, config: Config, opts: Options) {
+    let backends = backends::Backends::new(scope.scope("backends"));
+
+    let backend_reloads = scope.counter("backend_reloads").unwrap();
+
+    let (sender, tripwire) = Tripwire::new();
+    let mut run: FuturesUnordered<_> = config
+        .statsd
+        .servers
+        .iter()
+        .map({
+            |(server_name, server_config)| {
+                let name = server_name.clone();
+                statsd_server::run(
+                    scope.scope("statsd_server").scope(server_name),
+                    tripwire.clone(),
+                    server_config.clone(),
+                    backends.clone(),
+                )
+                .map(|_| name)
+            }
+        })
+        .collect();
+
+    // Trap ctrl+c and sigterm messages and perform a clean shutdown
+    let mut sigint = signal(SignalKind::interrupt()).unwrap();
+    let mut sigterm = signal(SignalKind::terminate()).unwrap();
+    tokio::spawn(async move {
+        select! {
+        _ = sigint.recv() => info!("received sigint"),
+        _ = sigterm.recv() => info!("received sigterm"),
+        }
+        sender.cancel();
+    });
+
+    // Trap sighup to support manual file reloading
+    let mut sighup = signal(SignalKind::hangup()).unwrap();
+    // This task is designed to asynchronously build backend configurations,
+    // which may in turn come from other data sources or discovery sources.
+    // This inherently races with bringing up servers, to the point where a
+    // server may not have any backends to dispatch to yet, if discovery is
+    // very slow. This is the intended state, as configuration of processors
+    // and any buffers should have already been performed.
+    //
+    // SIGHUP will attempt to reload backend configurations as well as any
+    // discovery changes.
+    tokio::spawn(async move {
+        let dconfig = config.discovery.unwrap_or_default();
+        let discovery_cache = discovery::Cache::new();
+        let mut discovery_stream =
+            discovery::reflector(discovery_cache.clone(), discovery::as_stream(&dconfig));
+        loop {
+            info!("loading configuration and updating backends");
+            backend_reloads.inc();
+            let config = load_backend_configs(&discovery_cache, &backends, opts.config.as_ref())
+                .await
+                .unwrap();
+            let dconfig = config.discovery.unwrap_or_default();
+
+            tokio::select! {
+                _ = sighup.recv() => {
+                    info!("received sighup");
+                    discovery_stream = discovery::reflector(discovery_cache.clone(), discovery::as_stream(&dconfig));
+                    info!("reloaded discovery stream");
+                }
+                Some(event) = discovery_stream.next() => {
+                    info!("updating discovery for map {}", event.0);
+                }
+            };
+        }
+    });
+
+    while let Some(name) = run.next().await {
+        debug!("server {} exited", name)
+    }
 }
 
 fn main() -> anyhow::Result<()> {
@@ -46,7 +127,7 @@ fn main() -> anyhow::Result<()> {
     let config = statsrelay::config::load(opts.config.as_ref())
         .with_context(|| format!("can't load config file from {}", opts.config))?;
     info!("loaded config file {}", opts.config);
-    debug!("bind address: {}", config.statsd.bind);
+    debug!("servers defined: {:?}", config.statsd.servers);
 
     let collector = stats::Collector::default();
 
@@ -67,60 +148,7 @@ fn main() -> anyhow::Result<()> {
     let scope = collector.scope("statsrelay");
 
     runtime.block_on(async move {
-        let backends = backends::Backends::new(scope.scope("backends"));
-
-        let backend_reloads = scope.counter("backend_reloads").unwrap();
-
-        let (sender, tripwire) = Tripwire::new();
-        let run = statsd_server::run(scope.scope("statsd_server"), tripwire, config.statsd.bind.clone(), backends.clone());
-
-        // Trap ctrl+c and sigterm messages and perform a clean shutdown
-        let mut sigint = signal(SignalKind::interrupt()).unwrap();
-        let mut sigterm = signal(SignalKind::terminate()).unwrap();
-        tokio::spawn(async move {
-            select! {
-            _ = sigint.recv() => info!("received sigint"),
-            _ = sigterm.recv() => info!("received sigterm"),
-            }
-            sender.cancel();
-        });
-
-        // Trap sighup to support manual file reloading
-        let mut sighup = signal(SignalKind::hangup()).unwrap();
-        // This task is designed to asynchronously build backend configurations,
-        // which may in turn come from other data sources or discovery sources.
-        // This inherently races with bringing up servers, to the point where a
-        // server may not have any backends to dispatch to yet, if discovery is
-        // very slow. This is the intended state, as configuration of processors
-        // and any buffers should have already been performed.
-        //
-        // SIGHUP will attempt to reload backend configurations as well as any
-        // discovery changes.
-        tokio::spawn(async move {
-            let dconfig = config.discovery.unwrap_or_default();
-            let discovery_cache = discovery::Cache::new();
-            let mut discovery_stream =
-                discovery::reflector(discovery_cache.clone(), discovery::as_stream(&dconfig));
-            loop {
-                info!("loading configuration and updating backends");
-                backend_reloads.inc();
-                let config = load_backend_configs(&discovery_cache, &backends, opts.config.as_ref()).await.unwrap();
-                let dconfig = config.discovery.unwrap_or_default();
-
-                tokio::select! {
-                    _ = sighup.recv() => {
-                        info!("received sighup");
-                        discovery_stream = discovery::reflector(discovery_cache.clone(), discovery::as_stream(&dconfig));
-                        info!("reloaded discovery stream");
-                    }
-                    Some(event) = discovery_stream.next() => {
-                        info!("updating discovery for map {}", event.0);
-                    }
-                };
-            }
-        });
-
-        run.await;
+        server(scope, config, opts).await;
     });
 
     drop(runtime);

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -147,9 +147,7 @@ fn main() -> anyhow::Result<()> {
 
     let scope = collector.scope("statsrelay");
 
-    runtime.block_on(async move {
-        server(scope, config, opts).await;
-    });
+    runtime.block_on(server(scope, config, opts));
 
     drop(runtime);
     info!("runtime terminated");

--- a/src/statsd_client.rs
+++ b/src/statsd_client.rs
@@ -209,10 +209,10 @@ async fn ticker(endpoint: String, sender: mpsc::Sender<bool>) {
     loop {
         sleep(SEND_DELAY).await;
         match sender.send(true).await {
-            Err(_) =>{
+            Err(_) => {
                 info!("ticker task {} exiting", endpoint);
                 return;
-            },
+            }
             Ok(_) => (),
         };
     }
@@ -278,7 +278,7 @@ async fn client_task(
             Err(_e) => {
                 info!("client task {} exiting", endpoint);
                 return;
-            },
+            }
             Ok(_) => (),
         };
         buf = BytesMut::with_capacity(INITIAL_BUF_CAPACITY);

--- a/src/statsd_server.rs
+++ b/src/statsd_server.rs
@@ -2,8 +2,10 @@ use bytes::{BufMut, BytesMut};
 use memchr::memchr;
 use statsdproto::statsd::StatsdPDU;
 use stream_cancel::Tripwire;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::unix;
+use tokio::net::{TcpListener, UnixListener, UnixStream};
 use tokio::select;
 use tokio::time::timeout;
 
@@ -17,6 +19,7 @@ use std::time::Duration;
 use log::{debug, info, warn};
 
 use crate::backends::Backends;
+use crate::config::StatsdServerConfig;
 use crate::stats;
 
 const TCP_READ_TIMEOUT: Duration = Duration::from_secs(62);
@@ -110,10 +113,11 @@ fn process_buffer_newlines(buf: &mut BytesMut) -> Vec<StatsdPDU> {
     return ret;
 }
 
-async fn client_handler(
+async fn client_handler<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static>(
     stats: stats::Scope,
+    peer: String,
     mut tripwire: Tripwire,
-    mut socket: TcpStream,
+    mut socket: T,
     backends: Backends,
 ) {
     let mut buf = BytesMut::with_capacity(READ_BUFFER);
@@ -138,10 +142,7 @@ async fn client_handler(
 
         match result {
             Ok(bytes) if buf.is_empty() && bytes == 0 => {
-                debug!(
-                    "closing reader (empty buffer, eof) {:?}",
-                    socket.peer_addr()
-                );
+                debug!("closing reader (empty buffer, eof) {}", peer);
                 break;
             }
             Ok(bytes) if bytes == 0 => {
@@ -160,7 +161,7 @@ async fn client_handler(
                     None => (),
                 };
                 debug!("remaining {:?}", buf);
-                debug!("closing reader {:?}", socket.peer_addr());
+                debug!("closing reader {}", peer);
                 break;
             }
             Ok(bytes) => {
@@ -182,11 +183,11 @@ async fn client_handler(
                 break;
             }
             Err(e) if e.kind() == ErrorKind::TimedOut => {
-                debug!("read timeout, closing {:?}", socket.peer_addr());
+                debug!("read timeout, closing {}", peer);
                 break;
             }
             Err(e) => {
-                debug!("socket error {:?} from {:?}", e, socket.peer_addr());
+                debug!("socket error {:?} {}", e, peer);
                 break;
             }
         }
@@ -194,43 +195,90 @@ async fn client_handler(
     disconnects.inc();
 }
 
-pub async fn run(stats: stats::Scope, tripwire: Tripwire, bind: String, backends: Backends) {
-    //self.shutdown_trigger = Some(trigger);
-    let listener = TcpListener::bind(bind.as_str()).await.unwrap();
+/// Wrapper type to adapt an optional listener and either return an accept
+/// future, or a pending future which never returns. This wrapper is needed to
+/// work around that .accept() is an opaque impl Future type, so can't be
+/// readily mixed into a stream.
+async fn optional_accept(
+    listener: Option<&UnixListener>,
+) -> std::io::Result<(UnixStream, unix::SocketAddr)> {
+    if listener.is_some() {
+        listener.unwrap().accept().await
+    } else {
+        futures::future::pending::<std::io::Result<(UnixStream, unix::SocketAddr)>>().await
+    }
+}
+
+pub async fn run(
+    stats: stats::Scope,
+    tripwire: Tripwire,
+    config: StatsdServerConfig,
+    backends: Backends,
+) {
+    let tcp_listener = TcpListener::bind(config.bind.as_str()).await.unwrap();
+    info!("statsd tcp server running on {}", config.bind);
+
+    let unix_listener = config.socket.as_ref().map(|socket| {
+        let unix = UnixListener::bind(socket.as_str()).unwrap();
+        info!("statsd unix server running on {}", socket);
+        unix
+    });
+
+    // Spawn the threaded, non-async blocking UDP server
     let mut udp = UdpServer::new();
-    let bind_clone = bind.clone();
-    let udp_join = udp.udp_worker(stats.scope("udp"), bind_clone, backends.clone());
-    info!("statsd tcp server running on {}", bind);
+    let udp_join = udp.udp_worker(stats.scope("udp"), config.bind.clone(), backends.clone());
 
     let accept_connections = stats.counter("accepts").unwrap();
+    let accept_connections_unix = stats.counter("accepts_unix").unwrap();
     let accept_failures = stats.counter("accept_failures").unwrap();
+    let accept_failures_unix = stats.counter("accept_failures_unix").unwrap();
 
     async move {
         loop {
             select! {
                 _ = tripwire.clone() => {
-                    info!("stopped tcp listener loop");
+                    info!("stopped stream listener loop");
                     return
                 }
-                socket_res = listener.accept() => {
-
-                match socket_res {
-                    Ok((socket, _)) => {
-                        debug!("accepted connection from {:?}", socket.peer_addr());
-                        accept_connections.inc();
-                        tokio::spawn(client_handler(stats.scope("connections"), tripwire.clone(), socket, backends.clone()));
-                    }
-                    Err(err) => {
-                        accept_failures.inc();
-                        info!("accept error = {:?}", err);
+                // Wrap the unix acceptor for different stats
+                unix_res = optional_accept(unix_listener.as_ref()) => {
+                    match unix_res {
+                        Ok((socket,_)) => {
+                            let peer_addr = format!("{:?}", socket.peer_addr());
+                            debug!("accepted unix connection from {:?}", socket.peer_addr());
+                            accept_connections_unix.inc();
+                            tokio::spawn(client_handler(stats.scope("connections_unix"), peer_addr, tripwire.clone(), socket, backends.clone()));
+                        }
+                        Err(err) => {
+                            accept_failures_unix.inc();
+                            info!("unix accept error = {:?}", err);
+                        }
                     }
                 }
-            }
+                socket_res = tcp_listener.accept() => {
+
+                    match socket_res {
+                        Ok((socket,_)) => {
+                            let peer_addr = format!("{:?}", socket.peer_addr());
+                            debug!("accepted connection from {:?}", socket.peer_addr());
+                            accept_connections.inc();
+                            tokio::spawn(client_handler(stats.scope("connections"), peer_addr, tripwire.clone(), socket, backends.clone()));
+                        }
+                        Err(err) => {
+                            accept_failures.inc();
+                            info!("accept error = {:?}", err);
+                        }
+                    }
+                }
             }
         }
     }
     .await;
     drop(udp);
+    // The socket file descriptor is not removed on teardown. Lets remove it if enabled.
+    if let Some(socket) = config.socket.as_ref() {
+        let _ = std::fs::remove_file(socket);
+    }
     tokio::task::spawn_blocking(move || {
         udp_join.join().unwrap();
     })


### PR DESCRIPTION
- New config structure to support multiple servers, on different
  sockets and ports. Currently each server dispatches to the same
  backends.
- Add support for UNIX domain sockets, as stream sockets.
- Small factoring of code for main().
- Remove dead and previously backwards-compatible-bridge config options.