### PR TITLE
First class parsing of statsd protocol units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,75 +219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
-dependencies = [
- "autocfg",
- "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -577,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes",
  "fnv",
@@ -599,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
 
 [[package]]
 name = "httpdate"
@@ -725,6 +662,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11b9b772d42a9cf7ff6742d4695054070432742b19cecea07e7c4eca8173d25"
+dependencies = [
+ "cfg-if",
+ "lexical-core",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,15 +751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "memoffset"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,12 +795,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "ntapi"
@@ -1074,16 +1019,6 @@ name = "protobuf"
 version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b7f4a129bb3754c25a4e04032a90173c68f85168f77118ac4cb4936e7f06f92"
-
-[[package]]
-name = "qp-trie"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3feac20f371627c3c9e1fe7cb9e98a0b058a27d0a79ca022a5666407f4fc7453"
-dependencies = [
- "new_debug_unreachable",
- "unreachable",
-]
 
 [[package]]
 name = "quote"
@@ -1427,14 +1362,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "statsdproto"
-version = "0.1.1"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6699353d39a97bcf47f1e182126eda7c43ce48874b5976cd5f252874e5025c"
-dependencies = [
- "bytes",
- "memchr",
-]
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statsrelay"
@@ -1445,25 +1376,22 @@ dependencies = [
  "built",
  "bytes",
  "chrono",
- "crossbeam",
- "crossbeam-utils",
  "dashmap",
  "env_logger",
  "futures",
  "hyper",
  "jemallocator",
+ "lexical",
  "log",
  "memchr",
  "murmur3",
  "parking_lot",
  "prometheus",
- "qp-trie",
  "regex",
  "rusoto_core",
  "rusoto_s3",
  "serde",
  "serde_json",
- "statsdproto",
  "stream-cancel",
  "structopt",
  "tempfile",
@@ -1844,15 +1772,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "url"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,12 +1800,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "built"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +133,12 @@ name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -138,6 +156,15 @@ dependencies = [
  "serde",
  "toml",
  "url",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -222,6 +249,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.10.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools 0.9.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +337,28 @@ checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -276,6 +406,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
@@ -473,6 +609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +762,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -751,6 +920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memoffset"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +1017,12 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -947,6 +1131,34 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "plotters"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1070,6 +1282,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1334,15 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1211,6 +1457,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1376,6 +1641,7 @@ dependencies = [
  "built",
  "bytes",
  "chrono",
+ "criterion",
  "dashmap",
  "env_logger",
  "futures",
@@ -1608,6 +1874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +2078,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +2157,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+
+[[package]]
+name = "web-sys"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,12 @@ prometheus = "0.11"
 # malloc
 jemallocator = "0.3.0"
 
+[[bench]]
+name = "statsd_benchmark"
+harness = false
+
 [dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
 tempfile = "3.1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,17 @@ hyper = { version = "0.14", features = ["server", "client", "runtime", "http2", 
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-qp-trie = "0.7"
 anyhow = "1.0"
 thiserror = "1.0"
 memchr = "2"
 stream-cancel = "0.8"
-crossbeam = "0.8"
-crossbeam-utils = "0.8"
 bytes = "1"
 parking_lot = "0.11"
 regex = "1"
 chrono = "0.4"
-statsdproto = "0.1"
 dashmap = "4"
 async-stream = "0.3"
+lexical = "5"
 
 # For discovery
 rusoto_core = "0.46"

--- a/benches/statsd_benchmark.rs
+++ b/benches/statsd_benchmark.rs
@@ -1,0 +1,21 @@
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::convert::TryInto;
+
+fn parse(line: &Bytes) -> Option<statsrelay::statsdproto::PDU> {
+    statsrelay::statsdproto::PDU::new(line.clone())
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let by = Bytes::from_static(
+        b"hello_world.worldworld_i_am_a_pumpkin:3|c|@1.0|#tags:tags,tags:tags,tags:tags,tags:tags",
+    );
+    c.bench_function("statsd pdu parsing", |b| b.iter(|| parse(black_box(&by))));
+    c.bench_function("statsd pdu conversion", |b| b.iter(|| {
+        let _: statsrelay::statsdproto::Owned = parse(black_box(&by)).unwrap().try_into().unwrap();
+    }));
+
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/statsd_benchmark.rs
+++ b/benches/statsd_benchmark.rs
@@ -2,8 +2,8 @@ use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::convert::TryInto;
 
-fn parse(line: &Bytes) -> Option<statsrelay::statsdproto::PDU> {
-    statsrelay::statsdproto::PDU::new(line.clone())
+fn parse(line: &Bytes) -> Result<statsrelay::statsd_proto::PDU, statsrelay::statsd_proto::ParseError> {
+    statsrelay::statsd_proto::PDU::parse(line.clone())
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -12,7 +12,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     );
     c.bench_function("statsd pdu parsing", |b| b.iter(|| parse(black_box(&by))));
     c.bench_function("statsd pdu conversion", |b| b.iter(|| {
-        let _: statsrelay::statsdproto::Owned = parse(black_box(&by)).unwrap().try_into().unwrap();
+        let _: statsrelay::statsd_proto::Owned = parse(black_box(&by)).unwrap().try_into().unwrap();
     }));
 
 }

--- a/benches/statsd_benchmark.rs
+++ b/benches/statsd_benchmark.rs
@@ -2,7 +2,9 @@ use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::convert::TryInto;
 
-fn parse(line: &Bytes) -> Result<statsrelay::statsd_proto::PDU, statsrelay::statsd_proto::ParseError> {
+fn parse(
+    line: &Bytes,
+) -> Result<statsrelay::statsd_proto::PDU, statsrelay::statsd_proto::ParseError> {
     statsrelay::statsd_proto::PDU::parse(line.clone())
 }
 
@@ -11,10 +13,12 @@ fn criterion_benchmark(c: &mut Criterion) {
         b"hello_world.worldworld_i_am_a_pumpkin:3|c|@1.0|#tags:tags,tags:tags,tags:tags,tags:tags",
     );
     c.bench_function("statsd pdu parsing", |b| b.iter(|| parse(black_box(&by))));
-    c.bench_function("statsd pdu conversion", |b| b.iter(|| {
-        let _: statsrelay::statsd_proto::Owned = parse(black_box(&by)).unwrap().try_into().unwrap();
-    }));
-
+    c.bench_function("statsd pdu conversion", |b| {
+        b.iter(|| {
+            let _: statsrelay::statsd_proto::Owned =
+                parse(black_box(&by)).unwrap().try_into().unwrap();
+        })
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 use regex::bytes::RegexSet;
-use statsdproto::statsd::StatsdPDU;
 use thiserror::Error;
 
 use crate::config;
@@ -12,6 +11,7 @@ use crate::discovery;
 use crate::shard::{statsrelay_compat_hash, Ring};
 use crate::stats;
 use crate::statsd_client::StatsdClient;
+use crate::statsdproto::PDU as StatsdPDU;
 
 use log::warn;
 

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -11,7 +11,7 @@ use crate::discovery;
 use crate::shard::{statsrelay_compat_hash, Ring};
 use crate::stats;
 use crate::statsd_client::StatsdClient;
-use crate::statsdproto::PDU as StatsdPDU;
+use crate::statsd_proto::PDU as StatsdPDU;
 
 use log::warn;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod shard;
 pub mod stats;
 pub mod statsd_client;
 pub mod statsd_server;
+pub mod statsdproto;
 pub mod built_info {
     // The file has been placed there by the build script.
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod shard;
 pub mod stats;
 pub mod statsd_client;
 pub mod statsd_server;
-pub mod statsdproto;
+pub mod statsd_proto;
 pub mod built_info {
     // The file has been placed there by the build script.
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod sampler;
 pub mod shard;
 pub mod stats;
 pub mod statsd_client;
-pub mod statsd_server;
 pub mod statsd_proto;
+pub mod statsd_server;
 pub mod built_info {
     // The file has been placed there by the build script.
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -1,7 +1,7 @@
 use murmur3;
 use std::io::Cursor;
 
-use crate::statsdproto::PDU as StatsdPDU;
+use crate::statsd_proto::PDU as StatsdPDU;
 
 // HASHLIB_SEED same as the legacy statsrelay code base
 const HASHLIB_SEED: u32 = 0xaccd3d34;
@@ -77,25 +77,25 @@ pub mod test {
 
         assert_eq!(
             *ring.pick_from(statsrelay_compat_hash(
-                &StatsdPDU::new(Bytes::copy_from_slice(b"apple:1|c")).unwrap()
+                &StatsdPDU::parse(Bytes::copy_from_slice(b"apple:1|c")).unwrap()
             )),
             2
         );
         assert_eq!(
             *ring.pick_from(statsrelay_compat_hash(
-                &StatsdPDU::new(Bytes::copy_from_slice(b"banana:1|c")).unwrap()
+                &StatsdPDU::parse(Bytes::copy_from_slice(b"banana:1|c")).unwrap()
             )),
             3
         );
         assert_eq!(
             *ring.pick_from(statsrelay_compat_hash(
-                &StatsdPDU::new(Bytes::copy_from_slice(b"orange:1|c")).unwrap()
+                &StatsdPDU::parse(Bytes::copy_from_slice(b"orange:1|c")).unwrap()
             )),
             0
         );
         assert_eq!(
             *ring.pick_from(statsrelay_compat_hash(
-                &StatsdPDU::new(Bytes::copy_from_slice(b"lemon:1|c")).unwrap()
+                &StatsdPDU::parse(Bytes::copy_from_slice(b"lemon:1|c")).unwrap()
             )),
             1
         );

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -1,7 +1,7 @@
 use murmur3;
 use std::io::Cursor;
 
-use statsdproto::statsd::StatsdPDU;
+use crate::statsdproto::PDU as StatsdPDU;
 
 // HASHLIB_SEED same as the legacy statsrelay code base
 const HASHLIB_SEED: u32 = 0xaccd3d34;

--- a/src/statsd_client.rs
+++ b/src/statsd_client.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::stats;
-use crate::statsdproto::PDU as StatsdPDU;
+use crate::statsd_proto::PDU as StatsdPDU;
 
 use log::{info, warn};
 

--- a/src/statsd_client.rs
+++ b/src/statsd_client.rs
@@ -1,6 +1,5 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use memchr::memchr;
-use statsdproto::statsd::StatsdPDU;
 use stream_cancel::{Trigger, Tripwire};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
@@ -12,6 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::stats;
+use crate::statsdproto::PDU as StatsdPDU;
 
 use log::{info, warn};
 

--- a/src/statsdproto.rs
+++ b/src/statsdproto.rs
@@ -1,0 +1,385 @@
+use bytes::BufMut;
+use bytes::Bytes;
+use memchr::{memchr, memchr2};
+use thiserror::Error;
+
+use std::{
+    convert::{TryFrom, TryInto},
+    vec,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Type {
+    Counter,
+    Timer,
+    Gauge,
+    DirectGauge,
+    Set,
+}
+
+impl TryFrom<&[u8]> for Type {
+    type Error = ParseError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() < 1 && value.len() > 2 {
+            return Err(ParseError::InvalidType);
+        }
+        match value[0] {
+            b'c' => Ok(Type::Counter),
+            b'm' => Ok(Type::Timer),
+            b'g' => Ok(Type::Gauge),
+            b'G' => Ok(Type::DirectGauge),
+            b's' => Ok(Type::Set),
+            _ => Err(ParseError::InvalidType),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ParseError {
+    #[error("invalid parsed value")]
+    InvalidValue,
+    #[error("invalid sample rate")]
+    InvalidSampleRate,
+    #[error("invalid type")]
+    InvalidType,
+    #[error("invalid tag")]
+    InvalidTag,
+}
+
+/// A Tag is a key:value pair of metric tags
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct Tag {
+    name: Vec<u8>,
+    value: Vec<u8>,
+}
+
+/// Parsed gives an owned structure which represents a parsed statsd protocol
+/// unit which owns all of its fields. When parsing, no canonicalization is
+/// performed by default.
+#[derive(Debug, Clone)]
+pub struct Parsed {
+    name: Vec<u8>,
+    mtype: Type,
+    value: f64,
+    sample_rate: Option<f64>,
+    tags: Vec<Tag>,
+}
+
+fn parse_tags(input: &[u8]) -> Result<Vec<Tag>, ParseError> {
+    // Its impossible to have a tag of less than "a:b", also short circuit for
+    // no tags
+    match input.len() {
+        len if len == 0 => return Ok(vec![]),
+        len if len < 3 => return Err(ParseError::InvalidTag),
+        _ => (),
+    };
+
+    let mut tags: Vec<Tag> = Vec::new();
+    let mut scan = input;
+    loop {
+        let key_index_end = match memchr2(b':', b',', &scan[0..]) {
+            Some(i) if scan[i] == b':' => i,
+            Some(_) => return Err(ParseError::InvalidTag),
+            None => return Err(ParseError::InvalidTag),
+        };
+        let name = &scan[0..key_index_end];
+        scan = &scan[key_index_end + 1..];
+        match memchr2(b':', b',', scan) {
+            None => {
+                tags.push(Tag {
+                    name: name.to_vec(),
+                    value: scan.to_vec(),
+                });
+                return Ok(tags);
+            }
+            Some(value_index_end) if scan[value_index_end] == b',' => {
+                tags.push(Tag {
+                    name: name.to_vec(),
+                    value: scan[0..value_index_end].to_vec(),
+                });
+                scan = &scan[value_index_end + 1..];
+            }
+            Some(_) => return Err(ParseError::InvalidTag),
+        };
+    }
+}
+
+impl TryFrom<PDU> for Parsed {
+    type Error = ParseError;
+
+    fn try_from(pdu: PDU) -> Result<Self, Self::Error> {
+        let value = match lexical::parse::<f64, _>(pdu.value()) {
+            Ok(v) => v,
+            Err(_) => return Err(ParseError::InvalidValue),
+        };
+        let sample_rate = pdu
+            .sample_rate()
+            .map(|sr| match lexical::parse::<f64, _>(sr) {
+                Ok(v) if (v > 0.0 && v <= 1.0) => Ok(v),
+                Ok(_) => Err(ParseError::InvalidSampleRate),
+                Err(_) => Err(ParseError::InvalidSampleRate),
+            })
+            .transpose()?;
+        let mtype: Type = pdu.pdu_type().try_into()?;
+        let tags = pdu.tags().map(|v| parse_tags(v)).transpose()?;
+        Ok(Parsed {
+            name: pdu.name().to_vec(),
+            mtype: mtype,
+            value: value,
+            sample_rate: sample_rate,
+            tags: tags.unwrap_or_default(),
+        })
+    }
+}
+
+/// A PDU is an incoming protocol unit for statsd messages, commonly a
+/// single datagram or a line-delimitated message. This PDU type owns an
+/// incoming message and can offer references to protocol fields. It only
+/// performs limited parsing of the protocol unit.
+#[derive(Debug, Clone)]
+pub struct PDU {
+    underlying: Bytes,
+    value_index: usize,
+    type_index: usize,
+    type_index_end: usize,
+    sample_rate_index: Option<(usize, usize)>,
+    tags_index: Option<(usize, usize)>,
+}
+
+impl PDU {
+    pub fn name(&self) -> &[u8] {
+        &self.underlying[0..self.value_index - 1]
+    }
+
+    pub fn value(&self) -> &[u8] {
+        &self.underlying[self.value_index..self.type_index - 1]
+    }
+
+    pub fn pdu_type(&self) -> &[u8] {
+        &self.underlying[self.type_index..self.type_index_end]
+    }
+
+    pub fn tags(&self) -> Option<&[u8]> {
+        self.tags_index.map(|v| &self.underlying[v.0..v.1])
+    }
+
+    pub fn sample_rate(&self) -> Option<&[u8]> {
+        self.sample_rate_index.map(|v| &self.underlying[v.0..v.1])
+    }
+
+    pub fn len(&self) -> usize {
+        self.underlying.len()
+    }
+
+    pub fn as_ref(&self) -> &[u8] {
+        self.underlying.as_ref()
+    }
+
+    ///
+    /// Return a clone of the PDU with a prefix and suffix attached to the statsd name
+    ///
+    pub fn with_prefix_suffix(&self, prefix: &[u8], suffix: &[u8]) -> Self {
+        let offset = suffix.len() + prefix.len();
+
+        let mut buf = bytes::BytesMut::with_capacity(self.len() + offset);
+        buf.put(prefix);
+        buf.put(self.name());
+        buf.put(suffix);
+        buf.put(self.underlying[self.value_index - 1..].as_ref());
+
+        PDU {
+            underlying: buf.freeze(),
+            value_index: self.value_index + offset,
+            type_index: self.type_index + offset,
+            type_index_end: self.type_index_end + offset,
+            sample_rate_index: self
+                .sample_rate_index
+                .map(|(b, e)| (b + offset, e + offset)),
+            tags_index: self.tags_index.map(|(b, e)| (b + offset, e + offset)),
+        }
+    }
+
+    /// Parse an incoming single protocol unit and capture internal field
+    /// offsets for the positions and lengths of various protocol fields for
+    /// later access. No parsing or validation of values is done, so at a low
+    /// level this can be used to pass through unknown types and protocols.
+    pub fn new(line: Bytes) -> Option<Self> {
+        let length = line.len();
+        let mut value_index: usize = 0;
+        // To support inner ':' symbols in a metric name (more common than you
+        // think) we'll first find the index of the first type separator, and
+        // then do a walk to find the last ':' symbol before that.
+        let type_index = memchr('|' as u8, &line)? + 1;
+
+        loop {
+            let value_check_index = memchr(':' as u8, &line[value_index..type_index]);
+            match (value_check_index, value_index) {
+                (None, x) if x <= 0 => return None,
+                (None, _) => break,
+                _ => (),
+            }
+            value_index = value_check_index.unwrap() + value_index + 1;
+        }
+        let mut type_index_end = length;
+        let mut sample_rate_index: Option<(usize, usize)> = None;
+        let mut tags_index: Option<(usize, usize)> = None;
+
+        let mut scan_index = type_index;
+        loop {
+            let index = memchr('|' as u8, &line[scan_index..]).map(|v| v + scan_index);
+            match index {
+                None => break,
+                Some(x) if x + 2 >= length => break,
+                Some(x) if x < type_index_end => type_index_end = x,
+                _ => (),
+            }
+            match line[index.unwrap() + 1] {
+                b'@' => {
+                    if sample_rate_index.is_some() {
+                        return None;
+                    }
+                    sample_rate_index = index.map(|v| (v + 2, length));
+                    tags_index = tags_index.map(|(v, _l)| (v, index.unwrap()));
+                }
+                b'#' => {
+                    if tags_index.is_some() {
+                        return None;
+                    }
+                    tags_index = index.map(|v| (v + 2, length));
+                    sample_rate_index = sample_rate_index.map(|(v, _l)| (v, index.unwrap()));
+                }
+                _ => return None,
+            }
+            scan_index = index.unwrap() + 1;
+        }
+        Some(PDU {
+            underlying: line,
+            value_index,
+            type_index,
+            type_index_end,
+            sample_rate_index: sample_rate_index,
+            tags_index: tags_index,
+        })
+    }
+}
+
+#[cfg(test)]
+pub mod atest {
+    use super::*;
+    use anyhow::anyhow;
+
+    #[test]
+    fn parse_pdus() -> anyhow::Result<()> {
+        let valid: Vec<Vec<u8>> = vec![
+            b"foo.bar:3|c".to_vec(),
+            b"car:bar:3|c".to_vec(),
+            b"hello.bar:4.0|ms|#tags".to_vec(),
+            b"hello.bar:4.0|ms|@1.0|#tags".to_vec(),
+        ];
+        for buf in valid {
+            println!("{}", String::from_utf8(buf.clone())?);
+            PDU::new(buf.into()).ok_or(anyhow!("no pdu"))?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn simple_pdu() {
+        let pdu = PDU::new(Bytes::from_static(b"foo.car:bar:3.0|c")).unwrap();
+        assert_eq!(pdu.name(), b"foo.car:bar");
+        assert_eq!(pdu.value(), b"3.0");
+        assert_eq!(pdu.pdu_type(), b"c")
+    }
+
+    #[test]
+    fn tagged_pdu() {
+        let pdu = PDU::new(Bytes::from_static(b"foo.bar:3|c|@1.0|#tags")).unwrap();
+        assert_eq!(pdu.name(), b"foo.bar");
+        assert_eq!(pdu.value(), b"3");
+        assert_eq!(pdu.pdu_type(), b"c");
+        assert_eq!(pdu.tags().unwrap(), b"tags");
+        assert_eq!(pdu.sample_rate().unwrap(), b"1.0");
+    }
+
+    #[test]
+    fn tagged_pdu_reverse() {
+        let pdu = PDU::new(Bytes::from_static(b"foo.bar:3|c|#tags|@1.0")).unwrap();
+        assert_eq!(pdu.name(), b"foo.bar");
+        assert_eq!(pdu.value(), b"3");
+        assert_eq!(pdu.pdu_type(), b"c");
+        assert_eq!(pdu.tags().unwrap(), b"tags");
+        assert_eq!(pdu.sample_rate().unwrap(), b"1.0");
+    }
+
+    #[test]
+    fn prefix_suffix_test() {
+        let opdu = PDU::new(Bytes::from_static(b"foo.bar:3|c|#tags|@1.0")).unwrap();
+        let pdu = opdu.with_prefix_suffix(b"aa", b"bbb");
+        assert_eq!(pdu.name(), b"aafoo.barbbb");
+        assert_eq!(pdu.value(), b"3");
+        assert_eq!(pdu.pdu_type(), b"c");
+        assert_eq!(pdu.tags().unwrap(), b"tags");
+        assert_eq!(pdu.sample_rate().unwrap(), b"1.0");
+    }
+
+    #[test]
+    fn test_parse_tag() {
+        let tag_v = b"name:value";
+        let r = parse_tags(tag_v).unwrap();
+        assert!(r.len() == 1);
+        assert_eq!(r[0].name, b"name");
+        assert_eq!(r[0].value, b"value");
+    }
+
+    #[test]
+    fn test_parse_tag_invalid() {
+        let tag_v = b"name";
+        let r = parse_tags(tag_v);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn test_parse_tag_none() {
+        let tag_v = b"";
+        let r = parse_tags(tag_v).unwrap();
+        assert!(r.len() == 0);
+    }
+
+    #[test]
+    fn test_parse_tag_multiple() {
+        let tag_v = b"name:value,name2:value2,name3:value3";
+        let r = parse_tags(tag_v).unwrap();
+        assert!(r.len() == 3);
+        assert_eq!(r[0].name, b"name");
+        assert_eq!(r[0].value, b"value");
+        assert_eq!(r[1].name, b"name2");
+        assert_eq!(r[1].value, b"value2");
+        assert_eq!(r[2].name, b"name3");
+        assert_eq!(r[2].value, b"value3");
+    }
+
+    #[test]
+    fn test_parse_tag_multiple_invalid() {
+        let tag_v = b"name:value,name2,name3:value3";
+        let p = parse_tags(tag_v);
+        assert!(p.is_err());
+    }
+
+    #[test]
+    fn parsed_simple() {
+        let pdu = PDU::new(Bytes::from_static(b"foo.bar:3|c|#tags:value|@1.0")).unwrap();
+        let parsed: Parsed = pdu.try_into().unwrap();
+        assert_eq!(parsed.value, 3.0);
+        assert_eq!(parsed.name, b"foo.bar");
+        assert_eq!(parsed.mtype, Type::Counter);
+        assert_eq!(parsed.sample_rate, Some(1.0));
+        assert_eq!(
+            parsed.tags[0],
+            Tag {
+                name: b"tags".to_vec(),
+                value: b"value".to_vec()
+            }
+        );
+    }
+}


### PR DESCRIPTION
- Introduce parser locally Convert the slice-reference byte-backed PDU
- object to a copied-owned-byte structure, parsing the common units to
  internal structures and data types.

This PR doesn't introduce canonicalization and sharding-hash
caching. More tests for extreme parsing examples are needed.