### PR TITLE
Support directed propagation from servers to backends

### DIFF
--- a/examples/tugboat-discovery.json
+++ b/examples/tugboat-discovery.json
@@ -3,7 +3,8 @@
         "servers": {
             "default": {
                 "bind": "127.0.0.1:8129",
-                "socket": "/tmp/statsrelay"
+                "socket": "/tmp/statsrelay",
+                "route": ["statsd:simple", "statsd:path_discovery"]
             }
         },
         "backends": {

--- a/examples/tugboat-legacy-basic.json
+++ b/examples/tugboat-legacy-basic.json
@@ -5,7 +5,8 @@
     "statsd": {
         "servers": {
             "default": {
-                "bind": "127.0.0.1:8129"
+                "bind": "127.0.0.1:8129",
+                "route": ["statsd:simple"]
             }
         },
         "backends": {

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -200,12 +200,14 @@ impl BackendsInner {
         self.statsd.keys().collect()
     }
 
-    fn provide_statsd_pdu(&self, pdu: StatsdPDU) {
-        let _result: Vec<_> = self
-            .statsd
-            .iter()
-            .map(|(_, backend)| backend.provide_statsd_pdu(&pdu))
-            .collect();
+    fn provide_statsd_pdu(&self, pdu: StatsdPDU, route: &[config::Route]) {
+        let _r = route.iter().map(|dest| match dest.route_type {
+            config::RouteType::Statsd => self
+                .statsd
+                .get(dest.route_to.as_str())
+                .map(|backend| backend.provide_statsd_pdu(&pdu)),
+            config::RouteType::Processor => unimplemented!(),
+        });
     }
 }
 
@@ -253,7 +255,7 @@ impl Backends {
         self.inner.read().len()
     }
 
-    pub fn provide_statsd_pdu(&self, pdu: StatsdPDU) {
-        self.inner.read().provide_statsd_pdu(pdu)
+    pub fn provide_statsd_pdu(&self, pdu: StatsdPDU, route: &[config::Route]) {
+        self.inner.read().provide_statsd_pdu(pdu, route)
     }
 }

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -126,8 +126,8 @@ impl StatsdBackend {
         memoize
     }
 
-    fn provide_statsd(&self, input: StatsdSample) {
-        let pdu: statsd_proto::PDU = input.into();
+    fn provide_statsd(&self, input: &StatsdSample) {
+        let pdu: statsd_proto::PDU = input.clone().into();
         if !self
             .input_filter
             .as_ref()
@@ -232,12 +232,12 @@ impl BackendsInner {
         self.statsd.keys().collect()
     }
 
-    fn provide_statsd(&self, pdu: StatsdSample, route: &[config::Route]) {
+    fn provide_statsd(&self, pdu: &StatsdSample, route: &[config::Route]) {
         let _r = route.iter().map(|dest| match dest.route_type {
             config::RouteType::Statsd => self
                 .statsd
                 .get(dest.route_to.as_str())
-                .map(|backend| backend.provide_statsd(pdu.clone())),
+                .map(|backend| backend.provide_statsd(pdu)),
             config::RouteType::Processor => unimplemented!(),
         });
     }
@@ -290,6 +290,6 @@ impl Backends {
     pub fn provide_statsd_pdu(&self, pdu: statsd_proto::PDU, route: &[config::Route]) {
         self.inner
             .read()
-            .provide_statsd(StatsdSample::PDU(pdu), route)
+            .provide_statsd(&StatsdSample::PDU(pdu), route)
     }
 }

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -29,7 +29,7 @@ use log::warn;
 /// use statsrelay::backends::StatsdSample;
 ///
 /// let input = Bytes::from_static(b"foo.bar:3|c|#tags:value|@1.0");
-/// let sample = StatsdSample::PDU(statsd_proto::PDU::parse(input).unwrap());
+/// let sample = &StatsdSample::PDU(statsd_proto::PDU::parse(input).unwrap());
 /// let parsed: statsd_proto::PDU = sample.into();
 /// ```
 #[derive(Clone, Debug)]
@@ -42,6 +42,15 @@ impl From<StatsdSample> for statsd_proto::PDU {
     fn from(inp: StatsdSample) -> Self {
         match inp {
             StatsdSample::PDU(pdu) => pdu,
+            StatsdSample::Parsed(p) => p.into(),
+        }
+    }
+}
+
+impl From<&StatsdSample> for statsd_proto::PDU {
+    fn from(inp: &StatsdSample) -> Self {
+        match inp {
+            StatsdSample::PDU(pdu) => pdu.clone(),
             StatsdSample::Parsed(p) => p.into(),
         }
     }
@@ -127,7 +136,7 @@ impl StatsdBackend {
     }
 
     fn provide_statsd(&self, input: &StatsdSample) {
-        let pdu: statsd_proto::PDU = input.clone().into();
+        let pdu: statsd_proto::PDU = input.into();
         if !self
             .input_filter
             .as_ref()

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -11,21 +11,38 @@ use crate::discovery;
 use crate::shard::{statsrelay_compat_hash, Ring};
 use crate::stats;
 use crate::statsd_client::StatsdClient;
-use crate::statsd_proto::PDU as StatsdPDU;
 use crate::statsd_proto;
 
 use log::warn;
 
-pub enum Sample {
-    PDU(StatsdPDU),
-    Parsed(statsd_proto::Owned)
+/// An either type representing one of the two forms of statsd protocols
+///
+/// In order to allow backends to operate on different levels of protocol
+/// decoding (fully decoded or just tokenized), backends take a Sample enum
+/// which represent either of the two formats, with easy conversions between
+/// them.
+///
+/// # Examples
+/// ```
+/// use statsrelay::statsd_proto;
+/// use bytes::Bytes;
+/// use statsrelay::backends::StatsdSample;
+///
+/// let input = Bytes::from_static(b"foo.bar:3|c|#tags:value|@1.0");
+/// let sample = StatsdSample::PDU(statsd_proto::PDU::parse(input).unwrap());
+/// let parsed: statsd_proto::PDU = sample.into();
+/// ```
+#[derive(Clone, Debug)]
+pub enum StatsdSample {
+    PDU(statsd_proto::PDU),
+    Parsed(statsd_proto::Owned),
 }
 
-impl <'a> From<&'a Sample> for &'a StatsdPDU {
-    fn from(inp: &'a Sample) -> Self {
-        match *inp {
-            Sample::PDU(ref pdu) => pdu,
-            Sample::Parsed(ref parsed) => parsed.into(),
+impl From<StatsdSample> for statsd_proto::PDU {
+    fn from(inp: StatsdSample) -> Self {
+        match inp {
+            StatsdSample::PDU(pdu) => pdu,
+            StatsdSample::Parsed(p) => p.into(),
         }
     }
 }
@@ -109,8 +126,8 @@ impl StatsdBackend {
         memoize
     }
 
-    fn provide_statsd(&self, input: &Sample) {
-        let pdu: &StatsdPDU = input.into();
+    fn provide_statsd(&self, input: StatsdSample) {
+        let pdu: statsd_proto::PDU = input.into();
         if !self
             .input_filter
             .as_ref()
@@ -123,15 +140,14 @@ impl StatsdBackend {
         let code = match ring_read.len() {
             0 => return, // In case of nothing to send, do nothing
             1 => 1 as u32,
-            _ => statsrelay_compat_hash(pdu),
+            _ => statsrelay_compat_hash(&pdu),
         };
         let client = ring_read.pick_from(code);
         let sender = client.sender();
 
         // Assign prefix and/or suffix
-        let pdu_clone: StatsdPDU;
-        if self.conf.prefix.is_some() || self.conf.suffix.is_some() {
-            pdu_clone = pdu.with_prefix_suffix(
+        let pdu_clone = if self.conf.prefix.is_some() || self.conf.suffix.is_some() {
+            pdu.with_prefix_suffix(
                 self.conf
                     .prefix
                     .as_ref()
@@ -142,10 +158,10 @@ impl StatsdBackend {
                     .as_ref()
                     .map(|s| s.as_bytes())
                     .unwrap_or_default(),
-            );
+            )
         } else {
-            pdu_clone = pdu.clone();
-        }
+            pdu
+        };
         match sender.try_send(pdu_clone) {
             Err(_e) => {
                 self.backend_fails.inc();
@@ -216,12 +232,12 @@ impl BackendsInner {
         self.statsd.keys().collect()
     }
 
-    fn provide_statsd(&self, pdu: Sample, route: &[config::Route]) {
+    fn provide_statsd(&self, pdu: StatsdSample, route: &[config::Route]) {
         let _r = route.iter().map(|dest| match dest.route_type {
             config::RouteType::Statsd => self
                 .statsd
                 .get(dest.route_to.as_str())
-                .map(|backend| backend.provide_statsd(&pdu)),
+                .map(|backend| backend.provide_statsd(pdu.clone())),
             config::RouteType::Processor => unimplemented!(),
         });
     }
@@ -271,7 +287,9 @@ impl Backends {
         self.inner.read().len()
     }
 
-    pub fn provide_statsd_pdu(&self, pdu: StatsdPDU, route: &[config::Route]) {
-        self.inner.read().provide_statsd(Sample::PDU(pdu), route)
+    pub fn provide_statsd_pdu(&self, pdu: statsd_proto::PDU, route: &[config::Route]) {
+        self.inner
+            .read()
+            .provide_statsd(StatsdSample::PDU(pdu), route)
     }
 }

--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -30,6 +30,9 @@ struct Options {
     #[structopt(short = "c", long = "--config", default_value = "/etc/statsrelay.json")]
     pub config: String,
 
+    #[structopt(long = "--config-check-and-exit")]
+    pub config_check: bool,
+
     #[structopt(short = "t", long = "--threaded")]
     pub threaded: bool,
 }
@@ -128,6 +131,10 @@ fn main() -> anyhow::Result<()> {
         .with_context(|| format!("can't load config file from {}", opts.config))?;
     info!("loaded config file {}", opts.config);
     debug!("servers defined: {:?}", config.statsd.servers);
+    if opts.config_check {
+        info!("--config-check-and-exit set, exiting");
+        return Ok(());
+    }
 
     let collector = stats::Collector::default();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,81 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
-
-use serde::{Deserialize, Serialize};
+use std::convert::{AsRef, TryFrom, TryInto};
+use std::fmt;
 use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub enum RouteType {
+    Statsd,
+    Processor,
+}
+
+impl TryFrom<&str> for RouteType {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "statsd" => Ok(RouteType::Statsd),
+            "processor" => Ok(RouteType::Processor),
+            _ => Err(Error::UnknownRouteType(value.to_string())),
+        }
+    }
+}
+
+impl From<&RouteType> for &str {
+    fn from(t: &RouteType) -> Self {
+        match t {
+            RouteType::Statsd => "statsd",
+            RouteType::Processor => "processor",
+        }
+    }
+}
+
+impl fmt::Display for RouteType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s: &str = self.into();
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Route {
+    pub route_type: RouteType,
+    pub route_to: String,
+}
+
+impl fmt::Display for Route {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.route_type, self.route_to)
+    }
+}
+
+impl<'de> Deserialize<'de> for Route {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        let parts: Vec<&str> = s.split(':').collect();
+        if let [ty, to] = &parts[..] {
+            Ok(Route {
+                route_type: (*ty).try_into().map_err(serde::de::Error::custom)?,
+                route_to: (*to).into(),
+            })
+        } else {
+            Err(Error::MalformedRoute(s.to_string())).map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+impl Serialize for Route {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(format!("{}:{}", self.route_type, self.route_to).as_str())
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -19,12 +93,14 @@ pub enum Processor {
         timer_sampling_threshold: Option<u32>,
         timer_sampling_window: Option<u32>,
         reservoir_size: Option<u32>,
+
+        route: Vec<Route>,
     },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Processors {
-    pub processors: std::collections::HashMap<String, Processor>,
+    pub processors: HashMap<String, Processor>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -43,6 +119,7 @@ pub struct StatsdBackendConfig {
 pub struct StatsdServerConfig {
     pub bind: String,
     pub socket: Option<String>,
+    pub route: Vec<Route>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -110,12 +187,44 @@ pub struct Config {
 pub enum Error {
     #[error("could not locate discovery source {0}")]
     UnknownDiscoverySource(String),
+    #[error("malformed route {0}")]
+    MalformedRoute(String),
+    #[error("invalid route type {0}")]
+    UnknownRouteType(String),
+    #[error("invalid routing destination {0}")]
+    UnknownRoutingDestination(Route),
 }
 
-pub fn check_config(config: &Config) -> anyhow::Result<()> {
-    let default = Discovery::default();
-    let discovery = &config.discovery.as_ref().unwrap_or(&default);
-    // Every reference to a shard_map needs a reference to a valid discovery block
+fn check_config_route(config: &Config) -> Result<(), Error> {
+    for (_, statsd) in config.statsd.servers.iter() {
+        for route in statsd.route.iter() {
+            match route.route_type {
+                RouteType::Statsd => {
+                    config
+                        .statsd
+                        .backends
+                        .get(route.route_to.as_str())
+                        .ok_or(Error::UnknownRoutingDestination(route.clone()))
+                        .map(|_| ())?;
+                }
+                RouteType::Processor => {
+                    if let Some(procs) = &config.processor {
+                        procs
+                            .processors
+                            .get(route.route_to.as_str())
+                            .ok_or(Error::UnknownRoutingDestination(route.clone()))
+                            .map(|_| ())?;
+                    } else {
+                        return Err(Error::UnknownRoutingDestination(route.clone()));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_config_discovery(config: &Config, discovery: &Discovery) -> anyhow::Result<()> {
     for (_, statsd_dupl) in config.statsd.backends.iter() {
         if let Some(source) = &statsd_dupl.shard_map_source {
             if let None = discovery.sources.get(source) {
@@ -123,6 +232,15 @@ pub fn check_config(config: &Config) -> anyhow::Result<()> {
             }
         }
     }
+    Ok(())
+}
+
+fn check_config(config: &Config) -> anyhow::Result<()> {
+    let default = Discovery::default();
+    let discovery = &config.discovery.as_ref().unwrap_or(&default);
+    // Every reference to a shard_map needs a reference to a valid discovery block
+    check_config_discovery(config, discovery)?;
+    check_config_route(config)?;
     Ok(())
 }
 
@@ -147,7 +265,10 @@ pub mod test {
             "statsd": {
                 "servers": {
                     "default":
-                    { "bind": "127.0.0.1:BIND_STATSD_PORT" }
+                        {
+                            "bind": "127.0.0.1:BIND_STATSD_PORT",
+                            "route": ["statsd:test1"]
+                        }
                 },
                 "backends": {
                     "test1":

--- a/src/statsd_proto.rs
+++ b/src/statsd_proto.rs
@@ -174,12 +174,6 @@ impl From<Owned> for PDU {
     }
 }
 
-impl From<&Owned> for &PDU {
-    fn from(input: &Owned) -> Self {
-        input.into()
-    }
-}
-
 impl From<&Owned> for PDU {
     fn from(input: &Owned) -> Self {
         let mut bytes = Vec::with_capacity(input.name.len() + (input.tags.len() * 64) + 64);

--- a/src/statsd_proto.rs
+++ b/src/statsd_proto.rs
@@ -174,6 +174,12 @@ impl From<Owned> for PDU {
     }
 }
 
+impl From<&Owned> for &PDU {
+    fn from(input: &Owned) -> Self {
+        input.into()
+    }
+}
+
 impl From<&Owned> for PDU {
     fn from(input: &Owned) -> Self {
         let mut bytes = Vec::with_capacity(input.name.len() + (input.tags.len() * 64) + 64);


### PR DESCRIPTION
Refactors the servers to support directing at backends, and introduces
direction for processors. All config items now need a route: key which
lists the backend to send it to (e.g., statsd:backend1), or a
processor to send to (e.g. processor:clean_tags). Processors are
unimplemented in this PR.