### PR TITLE
Add RegexFilter processor

### DIFF
--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -213,6 +213,13 @@ async fn load_processors(
                     cardinality,
                 ))
             }
+            config::Processor::RegexFilter(regex) => {
+                info!("processor regex_filter: {:?}", regex);
+                Box::new(processors::regex_filter::RegexFilter::new(
+                    scope.scope(name),
+                    regex,
+                )?)
+            }
         };
         backends.replace_processor(name.as_str(), proc)?;
     }

--- a/src/processors/cardinality.rs
+++ b/src/processors/cardinality.rs
@@ -1,12 +1,15 @@
+use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 use std::time::{Duration, SystemTime};
-use std::convert::TryInto;
 
 use super::super::config;
 use super::super::statsd_proto::Event;
 use super::{Output, Processor};
-use crate::{backends::Backends, statsd_proto::{Owned, Parsed}};
 use crate::stats::{Counter, Gauge, Scope};
+use crate::{
+    backends::Backends,
+    statsd_proto::{Owned, Parsed},
+};
 
 use crate::cuckoofilter::{self, CuckooFilter};
 use ahash::AHasher;

--- a/src/processors/mod.rs
+++ b/src/processors/mod.rs
@@ -4,6 +4,7 @@ use crate::statsd_proto::Event;
 use smallvec::SmallVec;
 
 pub mod cardinality;
+pub mod regex_filter;
 pub mod sampler;
 pub mod tag;
 

--- a/src/processors/regex_filter.rs
+++ b/src/processors/regex_filter.rs
@@ -1,0 +1,92 @@
+use regex::RegexSet;
+
+use super::{Output, Processor};
+use crate::stats;
+use crate::{config::processor, statsd_proto::Event};
+use crate::{config::Route, statsd_proto::Parsed};
+
+pub struct RegexFilter {
+    allow: Option<RegexSet>,
+    remove: Option<RegexSet>,
+    route: Vec<Route>,
+
+    counter_remove: stats::Counter,
+}
+
+impl RegexFilter {
+    pub fn new(
+        scope: stats::Scope,
+        from_config: &processor::RegexFilter,
+    ) -> Result<Self, regex::Error> {
+        let allow = from_config.allow.as_ref().map(RegexSet::new).transpose()?;
+        let remove = from_config.remove.as_ref().map(RegexSet::new).transpose()?;
+        Ok(RegexFilter {
+            allow,
+            remove,
+            route: from_config.route.clone(),
+            counter_remove: scope.counter("removed").unwrap(),
+        })
+    }
+}
+
+impl Processor for RegexFilter {
+    fn provide_statsd(&self, event: &Event) -> Option<Output> {
+        let name = std::str::from_utf8(match event {
+            Event::Parsed(parsed) => parsed.id().name.as_ref(),
+            Event::Pdu(pdu) => pdu.name(),
+        })
+        .ok()?;
+        if let Some(allow) = &self.allow {
+            if !allow.is_match(name) {
+                self.counter_remove.inc();
+                return None;
+            }
+        }
+        if let Some(remove) = &self.remove {
+            if remove.is_match(name) {
+                self.counter_remove.inc();
+                return None;
+            }
+        }
+        Some(Output {
+            new_events: None,
+            route: self.route.as_ref(),
+        })
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+
+    use super::*;
+
+    #[test]
+    fn build_filter() {
+        let c = processor::RegexFilter {
+            route: vec![],
+            remove: Some(vec![r"^hello.*".to_owned(), r"^goodbye.*".to_owned()]),
+            allow: None,
+        };
+        let sink = stats::Collector::default();
+        let scope = sink.scope("prefix");
+        let filter = RegexFilter::new(scope, &c).unwrap();
+
+        let event1 = Event::Pdu(
+            crate::statsd_proto::Pdu::parse(bytes::Bytes::from_static(b"hello.world:c|1")).unwrap(),
+        );
+        let event2 = Event::Pdu(
+            crate::statsd_proto::Pdu::parse(bytes::Bytes::from_static(b"goodbye.world:c|1"))
+                .unwrap(),
+        );
+        let event3 = Event::Pdu(
+            crate::statsd_proto::Pdu::parse(bytes::Bytes::from_static(b"pineapples:c|1")).unwrap(),
+        );
+
+        assert!(filter.provide_statsd(&event1).is_none(), "should remove");
+        assert!(filter.provide_statsd(&event2).is_none(), "should remove");
+        assert!(
+            filter.provide_statsd(&event3).is_some(),
+            "should not remove"
+        );
+    }
+}


### PR DESCRIPTION
Sometimes you need a regex filter. At those trying times, you can use
this processor, which allows both "pass only if match" (the allow
option) or "remove if match" (the remove option).

This filter only operates on names, not on any potentially parsed
tags, as such it doesn't encounter any parsing conversion cost if the
message hasn't yet been parsed in the pipeline.