### PR TITLE
Update cuckoo filter with larger base size, avoid re-hashing

### DIFF
--- a/src/processors/cardinality.rs
+++ b/src/processors/cardinality.rs
@@ -31,7 +31,7 @@ where
 {
     fn new(valid_until: SystemTime) -> Self {
         TimeBoundedCuckoo {
-            filter: CuckooFilter::with_capacity((1 << 21) - 1),
+            filter: CuckooFilter::with_capacity((1 << 22) - 1),
             valid_until,
         }
     }
@@ -75,6 +75,7 @@ where
         let results: Result<Vec<_>, _> = self
             .filters
             .iter_mut()
+            .filter(|filter| !filter.filter.contains(data))
             .map(|filter| filter.filter.add(data))
             .collect();
         results.map(|_| ())
@@ -223,6 +224,8 @@ pub mod test {
         for name in &names[0..101] {
             assert!(filter.provide_statsd(name).is_some());
         }
+        let len = filter.filter.lock().len();
+        assert!(len == 101, "length isn't as expected {}", len);
         for name in &names[101..] {
             assert!(
                 filter.provide_statsd(name).is_none(),

--- a/src/processors/cardinality.rs
+++ b/src/processors/cardinality.rs
@@ -75,8 +75,7 @@ where
         let results: Result<Vec<_>, _> = self
             .filters
             .iter_mut()
-            .filter(|filter| !filter.filter.contains(data))
-            .map(|filter| filter.filter.add(data))
+            .map(|filter| filter.filter.test_and_add(data))
             .collect();
         results.map(|_| ())
     }


### PR DESCRIPTION
Re-calling add if contains is true causes multiple slots to be added
as the filter in a re-bucket hashing case. Avoid that.

Increase the base filter size by a power of two.