### PR TITLE
Fix buffer handling on incomplete buffer writes

### DIFF
--- a/src/statsd_client.rs
+++ b/src/statsd_client.rs
@@ -161,7 +161,7 @@ async fn client_sender(
                 }
                 Some(c) => c,
             };
-            // Keep on writing the buffer until success
+            // Write the buffer until success
             let result = connect.write_buf(&mut buf).await;
             match result {
                 Ok(0) if !buf.is_empty() => {
@@ -171,11 +171,9 @@ async fn client_sender(
                     connections_aborted.inc();
                     continue;
                 }
-                Ok(0) if buf.is_empty() => {
+                Ok(bytes) if buf.is_empty() => {
+                    bytes_sent.inc_by(bytes as f64);
                     drop(buf);
-                    break;
-                }
-                Ok(_) if !buf.is_empty() => {
                     break;
                 }
                 Ok(bytes) => {


### PR DESCRIPTION
If the OS does not perform a complete write of a buffer, we would
previously drop the buffer on the floor and not emit the needed
writes. We also wouldn't perform any accounting.

Remove the incorrect send logic, and replace with:

0 byte write with non-empty buffer: trim to next line, force
reconnect.

N byte write with empty buffer: account bytes, exit sending loop.

N byte write: account bytes, continue sending loop

Error: trim buffer to next known line, reconnect.