### PR TITLE
Don't panic on invalid configuration

### DIFF
--- a/src/cmd/statsrelay.rs
+++ b/src/cmd/statsrelay.rs
@@ -47,6 +47,7 @@ struct Options {
 /// configuration update loop, as well as register signal handlers.
 async fn server(scope: stats::Scope, config: Config, opts: Options) {
     let backend_reloads = scope.counter("backend_reloads").unwrap();
+    let config_load_failures = scope.counter("backend_reloads_failure").unwrap();
     let backends = backends::Backends::new(scope.scope("backends"));
 
     // Load processors
@@ -119,6 +120,7 @@ async fn server(scope: stats::Scope, config: Config, opts: Options) {
                     config
                 }
                 Err(e) => {
+                    config_load_failures.inc();
                     error!("error reloading configuration from disk, using original configuration: {:?}", e);
                     last_config.clone()
                 }


### PR DESCRIPTION
If the configuration was invalid, this async task would panic and no
further configuration reloads would occur.

This is a kludgy fix but is simple to read.